### PR TITLE
Upgrade quinn-proto to 0.11.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5799,9 +5799,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "fastbloom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,7 +349,7 @@ protosol = "2.0.0"
 qstring = "0.7.2"
 qualifier_attr = { version = "0.2.2", default-features = false }
 quinn = "0.11.9"
-quinn-proto = "0.11.13"
+quinn-proto = "0.11.14"
 quote = "1.0"
 rand = "0.8.5"
 rand0-7 = { package = "rand", version = "0.7" }


### PR DESCRIPTION
## Summary
- Upgrades quinn-proto from 0.11.13 to 0.11.14 in workspace Cargo.toml
- Updates Cargo.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)